### PR TITLE
Update address watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Blockchain.watchAddress({
 })
 ```
 
+### Stop watching an address
+Use the ID returned from the `watchAddress()` method to stop watching the address.
+```typescript
+const watcher = await Blockchain.watchAddress({
+    address: '3HoDXkm5iY...',
+    webhookUrl: 'https://example.com/ipn/btc',
+});
+
+await Blockchain.stopWatch(watcher.id); // { deleted: true/false }
+```
+
 ## Notes
 While this wrapper takes care of most for you, it is still encouraged that you go over the API docs as there are some
 caveats with address generation. Particularly in instances where one creates more than 20 unused addresses - this will

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    "testEnvironment": "node",
     "roots": [
         "<rootDir>/src"
     ],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "config": "^3.2.4",
     "jest": "^24.9.0",
     "ts-jest": "^24.1.0",
-    "typescript": "^3.6.4"
+    "typescript": "^4.0.5"
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "axios": "^0.19.0",
+    "axios": "^0.21.0",
     "qs": "^6.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockchain-payments-node",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Blockahain.info Payments wrapper for Node.js",
   "main": "dist/BlockchainPayments.js",
   "types": "dist/BlockchainPayments.d.ts",

--- a/src/BlockchainPayments.spec.ts
+++ b/src/BlockchainPayments.spec.ts
@@ -31,7 +31,10 @@ describe('BlockchainPayments', () => {
      */
     afterAll(() => {
         return Promise.all(watchers.map(async (id) => {
-            await Blockchain.stopWatch(id);
+            await Blockchain.stopWatch(id).catch((error) => {
+                console.error(error);
+                throw error;
+            });
         }))
     })
 });

--- a/src/BlockchainPayments.spec.ts
+++ b/src/BlockchainPayments.spec.ts
@@ -4,6 +4,7 @@ import Config from 'config';
 describe('BlockchainPayments', () => {
     const Blockchain = new BlockchainPayments(Config.get('blockchain'));
     const webhookUrl = 'https://example.com?invoice_id=058921123';
+    const watchers: number[] = [];
 
     test('Can create payment addresses', async () => {
         const request = await Blockchain.createAddress({ webhookUrl });
@@ -12,4 +13,25 @@ describe('BlockchainPayments', () => {
         expect(request.callback).toBeDefined();
         expect(request.index).toBeDefined();
     });
+
+    test('Can watch Bitcoin addresses', async () => {
+        const response = await Blockchain.watchAddress({
+            address: '17KSXCEXhQjJ1bj4p7CsETZBAbieENcx42',
+            onNotification: 'DELETE',
+            confirmations: 1,
+            webhookUrl,
+        });
+
+        expect(response.id).toBeDefined();
+        watchers.push(response.id)
+    })
+
+    /**
+     * Stop all test-created watchers to avoid adding unnecessary event listeners to Blockchain.com
+     */
+    afterAll(() => {
+        return Promise.all(watchers.map(async (id) => {
+            await Blockchain.stopWatch(id);
+        }))
+    })
 });

--- a/src/BlockchainPayments.ts
+++ b/src/BlockchainPayments.ts
@@ -78,7 +78,7 @@ export default class BlockchainPayments {
     /**
      * Prepare querystring, including the API key using the given data.
      */
-    private buildQuery<T = KeyValue<string>>(data: Omit<T, 'key'>) {
+    private buildQuery<T = KeyValue<string>>(data?: Omit<T, 'key'>) {
         return {
             key: this.apiKey,
             ...data,

--- a/src/BlockchainPayments.ts
+++ b/src/BlockchainPayments.ts
@@ -102,20 +102,18 @@ export default class BlockchainPayments {
     /**
      * Monitor any Bitcoin address for incoming payments.
      */
-    public watchAddress(options: Method.Options.monitorAddress) {
-        const defaults: Partial<Method.Options.monitorAddress> = {
-            onNotification: 'KEEP',
-            confirmations: 1,
-            type: 'ALL',
-        };
-        const { address: addr, webhookUrl: callback, type: op, confirmations: confs, onNotification } = {
-            ...defaults,
-            ...options,
-        };
-
+    public watchAddress({
+        onNotification = 'KEEP',
+        confirmations = 1,
+        type = 'ALL',
+        address,
+        webhookUrl,
+    }: Method.Options.monitorAddress) {
         const query = this.buildQuery<BlockchainApi.BalanceUpdates.Request>({
-            addr, callback, op, confs,
-            // @ts-ignore
+            addr: address,
+            callback: webhookUrl,
+            op: type,
+            confs: confirmations,
             onNotification,
         });
 

--- a/src/BlockchainPayments.ts
+++ b/src/BlockchainPayments.ts
@@ -127,6 +127,18 @@ export default class BlockchainPayments {
     }
 
     /**
+     * Stop address watching for the given watcher ID.
+     * IDs are returned by the watchAddress() method's response body.
+     */
+    stopWatch(id: number) {
+        return this.api.delete(`/block_notification/${id}`, {
+            params: this.buildQuery(),
+        }).then((response: AxiosResponse<BlockchainApi.StopBalanceUpdates.Response>) => {
+            return response.data;
+        })
+    }
+
+    /**
      * Update the currently used xPub to the given xPub.
      */
     public setXPub(xpub: string) {

--- a/src/BlockchainPayments.ts
+++ b/src/BlockchainPayments.ts
@@ -113,12 +113,16 @@ export default class BlockchainPayments {
             ...options,
         };
 
-        return this.api.post('/balance_update', {
-            params: this.buildQuery<BlockchainApi.BalanceUpdates.Request>({
-                addr, callback, op, confs,
-                // @ts-ignore
-                onNotification,
-            }),
+        const query = this.buildQuery<BlockchainApi.BalanceUpdates.Request>({
+            addr, callback, op, confs,
+            // @ts-ignore
+            onNotification,
+        });
+
+        return this.api.post('/balance_update', JSON.stringify(query), {
+            headers: {
+                'Content-Type': 'text/plain',
+            }
         }).then((response: AxiosResponse<BlockchainApi.BalanceUpdates.Response>) => {
             return response.data;
         });

--- a/src/BlockchainPayments.ts
+++ b/src/BlockchainPayments.ts
@@ -131,7 +131,7 @@ export default class BlockchainPayments {
      * IDs are returned by the watchAddress() method's response body.
      */
     stopWatch(id: number) {
-        return this.api.delete(`/block_notification/${id}`, {
+        return this.api.delete(`/balance_update/${id}`, {
             params: this.buildQuery(),
         }).then((response: AxiosResponse<BlockchainApi.StopBalanceUpdates.Response>) => {
             return response.data;

--- a/src/Interfaces/BlockchainApi.ts
+++ b/src/Interfaces/BlockchainApi.ts
@@ -114,4 +114,23 @@ export declare namespace BlockchainApi {
 
         }
     }
+
+    namespace StopBalanceUpdates {
+        interface Request extends ApiRequest {
+
+            /**
+             * ID returned from BalanceUpdates request.
+             */
+            id: number
+
+        }
+
+        interface Response {
+
+            /**
+             * Whether or not the delete request was successful.
+             */
+            deleted: boolean;
+        }
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue with `watchAddress()` where an improperly formatted request would be passed through to Blockchain.com. A new`stopWatch()` method has also been added for preventing further update requests from being sent out for a certain watcher.

Tests has also been added for `watchAddress()`

- [x] Documentation
- [x] Tests